### PR TITLE
Fix: DockerFile 수정

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     libsm6 \
     libxext6 \
+    libgl1-mesa-glx \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # 3. 작업 디렉토리 설정


### PR DESCRIPTION
OpenCV(cv2)가 필요로 하는 시스템 라이브러리(libGL.so.1)가 설치되지 않았기 때문에 배포시 오류가 발생했습니다. Dockerfile에 이 라이브러리를 직접 설치해주는 코드를 추가했습니다.